### PR TITLE
Add Google sign-in support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
     implementation("com.google.firebase:firebase-firestore-ktx")
     implementation("com.google.firebase:firebase-auth-ktx")
+    implementation("com.google.android.gms:play-services-auth:21.1.1")
     implementation("androidx.datastore:datastore-preferences:1.0.0")
 
     // Coroutines

--- a/app/src/main/java/com/example/ainotes/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/ainotes/data/repository/AuthRepository.kt
@@ -2,6 +2,7 @@ package com.example.ainotes.data.repository
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GoogleAuthProvider
 import kotlinx.coroutines.tasks.await
 
 class AuthRepository(
@@ -32,4 +33,15 @@ class AuthRepository(
     }
 
     fun getCurrentUser(): FirebaseUser? = auth.currentUser
+
+    // Sign in with Google ID token
+    suspend fun signInWithGoogle(idToken: String): Result<FirebaseUser> {
+        val credential = GoogleAuthProvider.getCredential(idToken, null)
+        return try {
+            val result = auth.signInWithCredential(credential).await()
+            Result.success(result.user!!)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add Google Play services auth dependency
- implement Google sign-in in auth repository and view model
- launch Google sign-in flow from sign-up options screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d27dc6488333bfcd78287018bed0