### PR TITLE
Enable continuous speech recognition for recording

### DIFF
--- a/app/src/main/java/com/example/ainotes/viewmodel/RecordingViewModel.kt
+++ b/app/src/main/java/com/example/ainotes/viewmodel/RecordingViewModel.kt
@@ -14,9 +14,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
+/**
+ * ViewModel that manages continuous speech recognition. The recognizer is restarted
+ * whenever speech ends or an error occurs so that the user can speak for as long as
+ * needed until they explicitly stop the recording.
+ */
 class RecordingViewModel : ViewModel() {
 
-    // Used to animate your waveform (from onRmsChanged)
+    // Used to animate the waveform
     private val _amplitude = MutableStateFlow(0)
     val amplitude: StateFlow<Int> = _amplitude
 
@@ -24,23 +29,21 @@ class RecordingViewModel : ViewModel() {
     private val _isRecording = MutableStateFlow(false)
     val isRecording: StateFlow<Boolean> = _isRecording
 
-    // Holds the final recognized text
+    // Accumulates the recognized text
     private val _recognizedText = MutableStateFlow("")
     val recognizedText: StateFlow<String> = _recognizedText
 
-    // SpeechRecognizer instance
     private var speechRecognizer: SpeechRecognizer? = null
+    private var recognizerIntent: Intent? = null
 
     /**
-     * Starts "recording" (i.e. speech recognition) by creating and starting a SpeechRecognizer.
-     * If a recognizer is already active, it stops it first.
+     * Begin listening for speech. The SpeechRecognizer is (re)created each time to avoid
+     * lingering state from a previous session.
      */
     fun startRecording(context: Context) {
         viewModelScope.launch {
-            // Stop any previous recognition if active
             stopRecordingInternal()
 
-            // Create a new SpeechRecognizer instance and set its listener
             speechRecognizer = SpeechRecognizer.createSpeechRecognizer(context).apply {
                 setRecognitionListener(object : RecognitionListener {
                     override fun onReadyForSpeech(params: Bundle?) {
@@ -51,55 +54,59 @@ class RecordingViewModel : ViewModel() {
                         Log.d("RecordingViewModel", "User started speaking")
                     }
                     override fun onRmsChanged(rmsdB: Float) {
-                        // Scale the RMS value for the waveform (tweak multiplier as needed)
                         val amp = (rmsdB * 2000).toInt().coerceIn(0, 32767)
                         _amplitude.value = amp
                     }
                     override fun onBufferReceived(buffer: ByteArray?) {}
                     override fun onEndOfSpeech() {
-                        _isRecording.value = false
                         Log.d("RecordingViewModel", "Speech ended")
+                        if (_isRecording.value) restartListening()
                     }
                     override fun onError(error: Int) {
-                        _isRecording.value = false
                         Log.e("RecordingViewModel", "Speech recognition error: $error")
+                        if (_isRecording.value) restartListening()
                     }
                     override fun onResults(results: Bundle?) {
                         val matches = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
                         if (!matches.isNullOrEmpty()) {
-                            _recognizedText.value = matches[0]
-                            Log.d("RecordingViewModel", "Recognized text: ${matches[0]}")
+                            val text = matches[0]
+                            _recognizedText.value = (_recognizedText.value + " " + text).trim()
+                            Log.d("RecordingViewModel", "Recognized text: $text")
+                        }
+                        if (_isRecording.value) restartListening()
+                    }
+                    override fun onPartialResults(partialResults: Bundle?) {
+                        val matches = partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                        if (!matches.isNullOrEmpty()) {
+                            val text = matches[0]
+                            _recognizedText.value = (_recognizedText.value + " " + text).trim()
                         }
                     }
-                    override fun onPartialResults(partialResults: Bundle?) {}
                     override fun onEvent(eventType: Int, params: Bundle?) {}
                 })
             }
 
-            // Create the speech recognition intent correctly using Intent constructor
-            val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            recognizerIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
                 putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
-                putExtra(RecognizerIntent.EXTRA_PROMPT, "Speak now...")
+                putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+                putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 3)
+                // Increase silence timeout so users can pause without stopping recognition
+                putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, 10000)
+                putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS, 10000)
             }
 
-            // Start listening
-            speechRecognizer?.startListening(intent)
+            startListening()
         }
     }
 
-    /**
-     * Stops the speech recognition.
-     * Calls an internal suspend function inside a coroutine.
-     */
+    /** Stop listening and release the SpeechRecognizer. */
     fun stopRecording() {
         viewModelScope.launch {
             stopRecordingInternal()
         }
     }
 
-    /**
-     * Cancels speech recognition and clears the recognized text.
-     */
+    /** Cancel the current session and clear any accumulated text. */
     fun cancelRecording() {
         viewModelScope.launch {
             stopRecordingInternal()
@@ -109,19 +116,25 @@ class RecordingViewModel : ViewModel() {
         }
     }
 
-    /**
-     * Private helper that stops the SpeechRecognizer if active.
-     */
     private suspend fun stopRecordingInternal() {
         if (_isRecording.value) {
-            Log.d("RecordingViewModel", "Stopping speech recognition...")
             _isRecording.value = false
             speechRecognizer?.stopListening()
-            // Wait briefly for final results (if needed)
+            // Allow time for any final results to be returned
             delay(200L)
         }
         _amplitude.value = 0
         speechRecognizer?.destroy()
         speechRecognizer = null
     }
+
+    private fun startListening() {
+        speechRecognizer?.startListening(recognizerIntent)
+    }
+
+    private fun restartListening() {
+        speechRecognizer?.cancel()
+        startListening()
+    }
 }
+


### PR DESCRIPTION
## Summary
- restart SpeechRecognizer when speech ends or errors to keep recording until user stops
- accumulate recognized text across sessions and allow longer pauses

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a203e1ff7c8333adf5b98ae7d56c68