### PR TITLE
Handle Firestore permission failures

### DIFF
--- a/app/src/main/java/com/example/ainotes/data/model/Transcript.kt
+++ b/app/src/main/java/com/example/ainotes/data/model/Transcript.kt
@@ -1,0 +1,10 @@
+package com.example.ainotes.data.model
+
+/**
+ * Represents a saved transcript.
+ */
+data class Transcript(
+    val id: String = "",
+    val text: String = "",
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/example/ainotes/data/repository/TranscriptsRepository.kt
+++ b/app/src/main/java/com/example/ainotes/data/repository/TranscriptsRepository.kt
@@ -1,0 +1,63 @@
+package com.example.ainotes.data.repository
+
+import android.util.Log
+import com.example.ainotes.data.model.Transcript
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Handles persistence of transcripts in Firebase Firestore.
+ */
+class TranscriptsRepository {
+    private val collection = Firebase.firestore.collection("transcripts")
+
+    /**
+     * Stream the list of transcripts, ordered by timestamp descending.
+     */
+    fun getTranscripts(): Flow<List<Transcript>> = callbackFlow {
+        val listener = collection
+            .orderBy("timestamp", Query.Direction.DESCENDING)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    Log.e("TranscriptsRepository", "Listen failed", error)
+                    trySend(emptyList())
+                    return@addSnapshotListener
+                }
+                val data = snapshot?.documents?.mapNotNull { doc ->
+                    doc.toObject(Transcript::class.java)?.copy(id = doc.id)
+                } ?: emptyList()
+                trySend(data)
+            }
+        awaitClose { listener.remove() }
+    }
+
+    suspend fun addTranscript(text: String) {
+        val transcript = Transcript(text = text)
+        try {
+            collection.add(transcript).await()
+        } catch (e: Exception) {
+            Log.e("TranscriptsRepository", "Failed to add transcript", e)
+        }
+    }
+
+    suspend fun updateTranscript(transcript: Transcript) {
+        try {
+            collection.document(transcript.id).set(transcript).await()
+        } catch (e: Exception) {
+            Log.e("TranscriptsRepository", "Failed to update transcript", e)
+        }
+    }
+
+    suspend fun deleteTranscript(id: String) {
+        try {
+            collection.document(id).delete().await()
+        } catch (e: Exception) {
+            Log.e("TranscriptsRepository", "Failed to delete transcript", e)
+        }
+    }
+}

--- a/app/src/main/java/com/example/ainotes/ui/Navigation.kt
+++ b/app/src/main/java/com/example/ainotes/ui/Navigation.kt
@@ -11,6 +11,7 @@ import com.example.ainotes.viewmodel.AuthViewModel
 import com.example.ainotes.viewmodel.MainViewModel
 import com.example.ainotes.viewmodel.RecordingViewModel
 import com.example.ainotes.viewmodel.SettingsViewModel
+import com.example.ainotes.viewmodel.TranscriptsViewModel
 
 @Composable
 fun AppNavigation(startWithOnboarding: Boolean, authViewModel: AuthViewModel) {
@@ -21,6 +22,7 @@ fun AppNavigation(startWithOnboarding: Boolean, authViewModel: AuthViewModel) {
     val mainViewModel: MainViewModel = viewModel()
     val recordingViewModel: RecordingViewModel = viewModel()
     val settingsViewModel: SettingsViewModel = viewModel()
+    val transcriptsViewModel: TranscriptsViewModel = viewModel()
 
     NavHost(navController = navController, startDestination = startDestination) {
         // Onboarding Screen
@@ -81,7 +83,16 @@ fun AppNavigation(startWithOnboarding: Boolean, authViewModel: AuthViewModel) {
         }
 
         composable("transcription") {
-            TranscriptionScreen(navController, recordingViewModel)
+            TranscriptionScreen(navController, recordingViewModel, transcriptsViewModel)
+        }
+
+        composable("transcripts") {
+            TranscriptsScreen(navController, transcriptsViewModel)
+        }
+
+        composable("transcript_detail/{id}") { backStackEntry ->
+            val id = backStackEntry.arguments?.getString("id") ?: ""
+            TranscriptDetailScreen(navController, id, transcriptsViewModel)
         }
 
 

--- a/app/src/main/java/com/example/ainotes/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/ainotes/ui/screens/MainScreen.kt
@@ -162,6 +162,16 @@ fun MainScreen(
                     modifier = Modifier.size(36.dp)
                 )
             }
+
+            /** Transcripts Button **/
+            TextButton(
+                onClick = { navController.navigate("transcripts") },
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(16.dp)
+            ) {
+                Text("Transcripts", color = Color.White)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/ainotes/ui/screens/TranscriptDetailScreen.kt
+++ b/app/src/main/java/com/example/ainotes/ui/screens/TranscriptDetailScreen.kt
@@ -1,0 +1,71 @@
+package com.example.ainotes.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.ainotes.viewmodel.TranscriptsViewModel
+
+@Composable
+fun TranscriptDetailScreen(navController: NavController, transcriptId: String, viewModel: TranscriptsViewModel) {
+    val transcripts by viewModel.transcripts.collectAsState()
+    val transcript = transcripts.find { it.id == transcriptId }
+    var text = remember { mutableStateOf(transcript?.text ?: "") }
+
+    Surface(modifier = Modifier.fillMaxSize()) {
+        if (transcript == null) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text("Transcript not found")
+            }
+            return@Surface
+        }
+        Column(modifier = Modifier.padding(16.dp).fillMaxSize(), verticalArrangement = Arrangement.SpaceBetween) {
+            OutlinedTextField(
+                value = text.value,
+                onValueChange = { text.value = it },
+                modifier = Modifier.fillMaxWidth().weight(1f)
+            )
+            Column {
+                Row(horizontalArrangement = Arrangement.spacedBy(16.dp), modifier = Modifier.fillMaxWidth()) {
+                    Button(
+                        onClick = {
+                            viewModel.updateTranscript(transcript.copy(text = text.value))
+                            navController.popBackStack()
+                        },
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Save") }
+                    Button(
+                        onClick = { navController.popBackStack() },
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Cancel") }
+                }
+                Button(
+                    onClick = {
+                        viewModel.deleteTranscript(transcript.id)
+                        navController.popBackStack()
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = Color.Red),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp)
+                ) { Text("Delete", color = Color.White) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/ainotes/ui/screens/TranscriptionScreen.kt
+++ b/app/src/main/java/com/example/ainotes/ui/screens/TranscriptionScreen.kt
@@ -14,11 +14,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.example.ainotes.viewmodel.RecordingViewModel
+import com.example.ainotes.viewmodel.TranscriptsViewModel
 
 @Composable
 fun TranscriptionScreen(
     navController: NavController,
-    viewModel: RecordingViewModel
+    viewModel: RecordingViewModel,
+    transcriptsViewModel: TranscriptsViewModel
 ) {
     // Collect the recognized text from the ViewModel
     val recognizedText by viewModel.recognizedText.collectAsState()
@@ -73,25 +75,48 @@ fun TranscriptionScreen(
                         }
                     }
                 }
-                // Button to return to Main screen
-                Button(
-                    onClick = {
-                        navController.navigate("main") {
-                            popUpTo("main") { inclusive = false }
-                        }
-                    },
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                    shape = RoundedCornerShape(50),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(50.dp)
+                // Actions to save or discard the transcript
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    Text(
-                        text = "Back to Main",
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = Color(0xFF1E3A8A)
-                    )
+                    Button(
+                        onClick = {
+                            if (recognizedText.isNotBlank()) {
+                                transcriptsViewModel.addTranscript(recognizedText)
+                            }
+                            navController.navigate("transcripts") {
+                                popUpTo("main")
+                            }
+                        },
+                        colors = ButtonDefaults.buttonColors(containerColor = Color.White),
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(50)
+                    ) {
+                        Text(
+                            text = "Save",
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFF1E3A8A)
+                        )
+                    }
+                    Button(
+                        onClick = {
+                            navController.navigate("main") {
+                                popUpTo("main") { inclusive = false }
+                            }
+                        },
+                        colors = ButtonDefaults.buttonColors(containerColor = Color.White),
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(50)
+                    ) {
+                        Text(
+                            text = "Discard",
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFF1E3A8A)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/ainotes/ui/screens/TranscriptsScreen.kt
+++ b/app/src/main/java/com/example/ainotes/ui/screens/TranscriptsScreen.kt
@@ -1,0 +1,55 @@
+package com.example.ainotes.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.ainotes.viewmodel.TranscriptsViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun TranscriptsScreen(navController: NavController, viewModel: TranscriptsViewModel) {
+    val transcripts by viewModel.transcripts.collectAsState()
+
+    Surface(modifier = Modifier.fillMaxSize()) {
+        if (transcripts.isEmpty()) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text("No transcripts saved yet")
+            }
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(transcripts) { transcript ->
+                    Column(
+                        modifier = Modifier
+                            .clickable { navController.navigate("transcript_detail/${transcript.id}") }
+                            .padding(16.dp)
+                    ) {
+                        Text(
+                            text = formatDate(transcript.timestamp),
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                        Text(transcript.text, style = MaterialTheme.typography.bodyLarge)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun formatDate(time: Long): String {
+    val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+    return sdf.format(Date(time))
+}

--- a/app/src/main/java/com/example/ainotes/viewmodel/TranscriptsViewModel.kt
+++ b/app/src/main/java/com/example/ainotes/viewmodel/TranscriptsViewModel.kt
@@ -1,0 +1,42 @@
+package com.example.ainotes.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.ainotes.data.model.Transcript
+import com.example.ainotes.data.repository.TranscriptsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel wrapping [TranscriptsRepository].
+ */
+class TranscriptsViewModel : ViewModel() {
+    private val repository = TranscriptsRepository()
+
+    private val _transcripts = MutableStateFlow<List<Transcript>>(emptyList())
+    val transcripts: StateFlow<List<Transcript>> = _transcripts
+
+    init {
+        viewModelScope.launch {
+            repository
+                .getTranscripts()
+                .catch { _transcripts.value = emptyList() }
+                .collectLatest { list -> _transcripts.value = list }
+        }
+    }
+
+    fun addTranscript(text: String) {
+        viewModelScope.launch { repository.addTranscript(text) }
+    }
+
+    fun updateTranscript(transcript: Transcript) {
+        viewModelScope.launch { repository.updateTranscript(transcript) }
+    }
+
+    fun deleteTranscript(id: String) {
+        viewModelScope.launch { repository.deleteTranscript(id) }
+    }
+}


### PR DESCRIPTION
## Summary
- avoid app crash when Firestore listener fails
- log failures for add/update/delete transcript operations
- handle transcript stream errors in view model

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a24fb9ff8083339bad54673fe5f1cc