### PR TITLE
Implement Firestore-backed notes repository

### DIFF
--- a/app/src/main/java/com/example/ainotes/data/firebase/FirestoreSource.kt
+++ b/app/src/main/java/com/example/ainotes/data/firebase/FirestoreSource.kt
@@ -1,4 +1,79 @@
 package com.example.ainotes.data.firebase
 
-class FirestoreSource {
+import com.example.ainotes.data.model.Note
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Simple abstraction over Firestore access for note documents. All notes are
+ * stored under the path `users/{uid}/notes` where `uid` is the currently
+ * authenticated user's id. The class exposes flows for realtime updates as
+ * well as suspend functions for creating, updating and deleting notes.
+ */
+class FirestoreSource(
+    private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance(),
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+) {
+
+    /** Returns the collection reference for the current user's notes. */
+    private fun notesCollection(): CollectionReference? {
+        val uid = auth.currentUser?.uid ?: return null
+        return firestore.collection("users").document(uid).collection("notes")
+    }
+
+    /**
+     * Observe all notes for the current user. The flow emits whenever the
+     * underlying Firestore snapshot changes.
+     */
+    fun getNotes(): Flow<List<Note>> = callbackFlow {
+        val collection = notesCollection()
+        if (collection == null) {
+            trySend(emptyList())
+            // If there is no authenticated user we close the flow with an error
+            close(IllegalStateException("User not authenticated"))
+            return@callbackFlow
+        }
+
+        val registration = collection.addSnapshotListener { snapshot, error ->
+            if (error != null) {
+                close(error)
+                return@addSnapshotListener
+            }
+            val notes = snapshot?.documents?.mapNotNull { doc ->
+                doc.toObject(Note::class.java)?.copy(id = doc.id)
+            } ?: emptyList()
+            trySend(notes)
+        }
+
+        awaitClose { registration.remove() }
+    }
+
+    /** Add a new note document. */
+    suspend fun addNote(note: Note) {
+        notesCollection()
+            ?.document(note.id)
+            ?.set(note)
+            ?.await()
+    }
+
+    /** Update an existing note document. */
+    suspend fun updateNote(note: Note) {
+        notesCollection()
+            ?.document(note.id)
+            ?.set(note)
+            ?.await()
+    }
+
+    /** Delete the note with the given id. */
+    suspend fun deleteNote(id: String) {
+        notesCollection()
+            ?.document(id)
+            ?.delete()
+            ?.await()
+    }
 }

--- a/app/src/main/java/com/example/ainotes/data/repository/NotesRepository.kt
+++ b/app/src/main/java/com/example/ainotes/data/repository/NotesRepository.kt
@@ -1,4 +1,23 @@
 package com.example.ainotes.data.repository
 
-class NotesRepository {
+import com.example.ainotes.data.firebase.FirestoreSource
+import com.example.ainotes.data.model.Note
+import kotlinx.coroutines.flow.Flow
+
+/** Repository that exposes CRUD operations for [Note]s backed by Firestore. */
+class NotesRepository(
+    private val firestoreSource: FirestoreSource = FirestoreSource()
+) {
+
+    /** Observe all notes for the current user. */
+    fun getNotes(): Flow<List<Note>> = firestoreSource.getNotes()
+
+    /** Add a new note. */
+    suspend fun addNote(note: Note) = firestoreSource.addNote(note)
+
+    /** Update an existing note. */
+    suspend fun updateNote(note: Note) = firestoreSource.updateNote(note)
+
+    /** Delete the note with the given id. */
+    suspend fun deleteNote(id: String) = firestoreSource.deleteNote(id)
 }

--- a/app/src/main/java/com/example/ainotes/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/com/example/ainotes/viewmodel/NotesViewModel.kt
@@ -2,21 +2,31 @@ package com.example.ainotes.viewmodel
 
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.ainotes.data.model.Note
+import com.example.ainotes.data.repository.NotesRepository
+import kotlinx.coroutines.launch
 
-class NotesViewModel : ViewModel() {
+class NotesViewModel(
+    private val repository: NotesRepository = NotesRepository()
+) : ViewModel() {
     private val _notes = mutableStateListOf<Note>()
     val notes: List<Note> get() = _notes
 
     init {
-        // Sample data
-        val now = System.currentTimeMillis()
-        _notes.addAll(
-            listOf(
-                Note(id = "1", timestamp = now - 60_000, content = "First sample note"),
-                Note(id = "2", timestamp = now, content = "Second sample note")
-            )
-        )
+        // Collect notes from repository and keep local state in sync
+        viewModelScope.launch {
+            repository.getNotes().collect { fetched ->
+                _notes.clear()
+                _notes.addAll(fetched)
+            }
+        }
+    }
+
+    fun addNote(content: String) {
+        val note = Note(content = content)
+        _notes.add(note)
+        viewModelScope.launch { repository.addNote(note) }
     }
 
     fun getNoteById(id: String): Note? = _notes.find { it.id == id }
@@ -24,20 +34,23 @@ class NotesViewModel : ViewModel() {
     fun toggleFavorite(id: String) {
         val index = _notes.indexOfFirst { it.id == id }
         if (index != -1) {
-            val note = _notes[index]
-            _notes[index] = note.copy(isFavorite = !note.isFavorite)
+            val updated = _notes[index].copy(isFavorite = !_notes[index].isFavorite)
+            _notes[index] = updated
+            viewModelScope.launch { repository.updateNote(updated) }
         }
     }
 
     fun updateNote(id: String, newContent: String) {
         val index = _notes.indexOfFirst { it.id == id }
         if (index != -1) {
-            val note = _notes[index]
-            _notes[index] = note.copy(content = newContent)
+            val updated = _notes[index].copy(content = newContent)
+            _notes[index] = updated
+            viewModelScope.launch { repository.updateNote(updated) }
         }
     }
 
     fun deleteNote(id: String) {
         _notes.removeAll { it.id == id }
+        viewModelScope.launch { repository.deleteNote(id) }
     }
 }


### PR DESCRIPTION
## Summary
- Add FirestoreSource with CRUD and realtime flow for user notes
- Create NotesRepository wrapping FirestoreSource operations
- Inject NotesRepository into NotesViewModel for reading and persisting notes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------