### PR TITLE
Enable continuous dictation for recording

### DIFF
--- a/app/src/main/java/com/example/ainotes/viewmodel/RecordingViewModel.kt
+++ b/app/src/main/java/com/example/ainotes/viewmodel/RecordingViewModel.kt
@@ -3,6 +3,8 @@ package com.example.ainotes.viewmodel
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
@@ -12,144 +14,127 @@ import androidx.lifecycle.viewModelScope
 import com.example.ainotes.data.model.Note
 import com.example.ainotes.data.repository.NotesRepository
 import com.google.firebase.auth.FirebaseAuth
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class RecordingViewModel : ViewModel() {
 
-    // Used to animate your waveform (from onRmsChanged)
     private val _amplitude = MutableStateFlow(0)
     val amplitude: StateFlow<Int> = _amplitude
 
-    // Indicates if speech recognition is active
     private val _isRecording = MutableStateFlow(false)
     val isRecording: StateFlow<Boolean> = _isRecording
 
-    // Indicates if transcription is in progress
     private val _isTranscribing = MutableStateFlow(false)
     val isTranscribing: StateFlow<Boolean> = _isTranscribing
 
-    // Holds the final recognized text
     private val _recognizedText = MutableStateFlow("")
     val recognizedText: StateFlow<String> = _recognizedText
 
-    // SpeechRecognizer instance
     private var speechRecognizer: SpeechRecognizer? = null
+    private val handler = Handler(Looper.getMainLooper())
+    private lateinit var recognizerIntent: Intent
+    private val finalText = StringBuilder()
 
-    // Repository and auth instances, plus current transcription id
     private val notesRepository: NotesRepository = NotesRepository()
     private val auth: FirebaseAuth = FirebaseAuth.getInstance()
     private var currentTranscriptionId: String? = null
 
-    /**
-     * Starts "recording" (i.e. speech recognition) by creating and starting a SpeechRecognizer.
-     * If a recognizer is already active, it stops it first.
-     */
+    private val recognitionListener = object : RecognitionListener {
+        override fun onReadyForSpeech(params: Bundle?) {
+            _isRecording.value = true
+        }
+
+        override fun onRmsChanged(rmsdB: Float) {
+            val amp = (rmsdB * 2000).toInt().coerceIn(0, 32767)
+            _amplitude.value = amp
+        }
+
+        override fun onBufferReceived(buffer: ByteArray?) {}
+
+        override fun onEndOfSpeech() {
+            _isRecording.value = false
+            _isTranscribing.value = true
+            scheduleRestart()
+        }
+
+        override fun onError(error: Int) {
+            _isRecording.value = false
+            _isTranscribing.value = false
+            if (error == 5 || error == 6 || error == 7) {
+                scheduleRestart()
+            } else {
+                Log.e("RecordingViewModel", "Speech recognition error: $error")
+            }
+        }
+
+        override fun onResults(results: Bundle?) {
+            val text =
+                results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()
+            if (!text.isNullOrEmpty()) {
+                appendText(text, true)
+                Log.d("RecordingViewModel", "Recognized text: $text")
+            }
+            _isTranscribing.value = false
+        }
+
+        override fun onPartialResults(partialResults: Bundle?) {
+            val text =
+                partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()
+            if (!text.isNullOrEmpty()) {
+                appendText(text, false)
+            }
+        }
+
+        override fun onEvent(eventType: Int, params: Bundle?) {}
+
+        override fun onBeginningOfSpeech() {}
+    }
+
     fun startRecording(context: Context) {
-        viewModelScope.launch {
-            // Stop any previous recognition if active
+        viewModelScope.launch(Dispatchers.Main) {
             stopRecordingInternal()
-            // Ensure a fresh transcription for each new session
             resetTranscription()
-
-            // Create a new SpeechRecognizer instance and set its listener
-            speechRecognizer = SpeechRecognizer.createSpeechRecognizer(context).apply {
-                setRecognitionListener(object : RecognitionListener {
-                    override fun onReadyForSpeech(params: Bundle?) {
-                        _isRecording.value = true
-                        Log.d("RecordingViewModel", "Ready for speech")
-                    }
-                    override fun onBeginningOfSpeech() {
-                        Log.d("RecordingViewModel", "User started speaking")
-                    }
-                    override fun onRmsChanged(rmsdB: Float) {
-                        // Scale the RMS value for the waveform (tweak multiplier as needed)
-                        val amp = (rmsdB * 2000).toInt().coerceIn(0, 32767)
-                        _amplitude.value = amp
-                    }
-                    override fun onBufferReceived(buffer: ByteArray?) {}
-                    override fun onEndOfSpeech() {
-                        _isRecording.value = false
-                        _isTranscribing.value = true
-                        Log.d("RecordingViewModel", "Speech ended")
-                    }
-                    override fun onError(error: Int) {
-                        _isRecording.value = false
-                        _isTranscribing.value = false
-                        Log.e("RecordingViewModel", "Speech recognition error: $error")
-                    }
-                    override fun onResults(results: Bundle?) {
-                        val matches = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
-                        if (!matches.isNullOrEmpty()) {
-                            _recognizedText.value = matches[0]
-                            Log.d("RecordingViewModel", "Recognized text: ${matches[0]}")
-                        }
-                        _isTranscribing.value = false
-                    }
-                    override fun onPartialResults(partialResults: Bundle?) {}
-                    override fun onEvent(eventType: Int, params: Bundle?) {}
-                })
+            if (speechRecognizer == null) {
+                speechRecognizer = SpeechRecognizer.createSpeechRecognizer(context).apply {
+                    setRecognitionListener(recognitionListener)
+                }
+                recognizerIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                    putExtra(
+                        RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                        RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
+                    )
+                    putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+                    putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
+                    putExtra("android.speech.extra.ENABLE_FORMATTING", "quality")
+                }
             }
-
-            // Create the speech recognition intent correctly using Intent constructor
-            val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-                putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
-                putExtra(RecognizerIntent.EXTRA_PROMPT, "Speak now...")
-                putExtra(
-                    RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS,
-                    3500
-                )
-            }
-
-            // Start listening
-            speechRecognizer?.startListening(intent)
+            scheduleRestart(0)
         }
     }
 
-    /**
-     * Stops the speech recognition.
-     * Calls an internal suspend function inside a coroutine.
-     */
     fun stopRecording() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.Main) {
             stopRecordingInternal()
         }
     }
 
-    /**
-     * Cancels speech recognition and clears the recognized text.
-     */
     fun cancelRecording() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.Main) {
             stopRecordingInternal()
             resetTranscription()
             _amplitude.value = 0
-            Log.d("RecordingViewModel", "Speech recognition canceled.")
         }
     }
 
-    /**
-     * Updates the recognized text manually, used when user edits the transcription.
-     */
     fun updateRecognizedText(newText: String) {
+        finalText.clear()
+        finalText.append(newText)
         _recognizedText.value = newText
     }
 
-    /**
-     * Resets the current transcription state, clearing any recognized text
-     * and forgetting the last saved document ID.
-     */
-    private fun resetTranscription() {
-        currentTranscriptionId = null
-        _recognizedText.value = ""
-    }
-
-    /**
-     * Saves or updates the transcription using [NotesRepository]. The note is stored under
-     * `users/{uid}/notes` in Firestore. Results are communicated via [onResult].
-     */
     fun saveTranscription(text: String, onResult: (Boolean) -> Unit = {}) {
         val uid = auth.currentUser?.uid
         if (uid == null) {
@@ -160,10 +145,11 @@ class RecordingViewModel : ViewModel() {
 
         val note = if (currentTranscriptionId == null) {
             Note(content = text)
-        } else { Note(id = currentTranscriptionId!!, content = text)
+        } else {
+            Note(id = currentTranscriptionId!!, content = text)
         }
 
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.Main) {
             try {
                 if (currentTranscriptionId == null) {
                     notesRepository.addNote(note)
@@ -181,21 +167,43 @@ class RecordingViewModel : ViewModel() {
         }
     }
 
-
-    /**
-     * Private helper that stops the SpeechRecognizer if active.
-     */
-    private suspend fun stopRecordingInternal() {
-        if (_isRecording.value) {
-            Log.d("RecordingViewModel", "Stopping speech recognition...")
-            _isRecording.value = false
-            speechRecognizer?.stopListening()
-            // Wait briefly for final results (if needed)
-            delay(200L)
+    private fun appendText(text: String, isFinal: Boolean) {
+        if (isFinal) {
+            finalText.append(text).append(' ')
+            _recognizedText.value = finalText.toString()
+        } else {
+            _recognizedText.value = finalText.toString() + text
         }
-        _isTranscribing.value = false
-        _amplitude.value = 0
+    }
+
+    private fun resetTranscription() {
+        currentTranscriptionId = null
+        finalText.clear()
+        _recognizedText.value = ""
+    }
+
+    private fun scheduleRestart(delay: Long = 500L) {
+        handler.post {
+            speechRecognizer?.stopListening()
+        }
+        handler.postDelayed({
+            try {
+                speechRecognizer?.startListening(recognizerIntent)
+            } catch (e: Exception) {
+                Log.e("RecordingViewModel", "Failed to start listening", e)
+            }
+        }, delay)
+    }
+
+    private fun stopRecordingInternal() {
+        handler.removeCallbacksAndMessages(null)
+        speechRecognizer?.stopListening()
+        speechRecognizer?.cancel()
         speechRecognizer?.destroy()
         speechRecognizer = null
+        _isRecording.value = false
+        _isTranscribing.value = false
+        _amplitude.value = 0
     }
 }
+


### PR DESCRIPTION
## Summary
- reuse a single `SpeechRecognizer` with a main-thread `Handler` for restartable continuous dictation
- append partial speech results and commit final segments for seamless transcription
- keep existing note save logic and state flows intact

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5eb89ba708333b644820c43bc5b1d