### PR TITLE
Add AI-generated note titles

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.0"
 }
 
+val geminiApiKey = (System.getenv("GEMINI_API_KEY")
+    ?: (project.findProperty("GEMINI_API_KEY") as? String)
+    ?: "")
+
 android {
     namespace = "com.example.ainotes"
     compileSdk = 35
@@ -15,9 +19,18 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
+
+        buildConfigField(
+            "String",
+            "GEMINI_API_KEY",
+            "\"${geminiApiKey.replace("\"", "\\\"")}\""
+        )
     }
 
-    buildFeatures { compose = true }
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
 
     // Let the Kotlin Compose plugin pick the right compiler extension.
     // (No composeOptions{} block needed.)
@@ -55,6 +68,8 @@ dependencies {
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.android.gms:play-services-auth:21.1.1")
     implementation("androidx.datastore:datastore-preferences:1.0.0")
+
+    implementation("com.google.ai.client.generativeai:generativeai:0.6.0")
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/app/src/main/java/com/example/ainotes/data/ai/NoteTitleGenerator.kt
+++ b/app/src/main/java/com/example/ainotes/data/ai/NoteTitleGenerator.kt
@@ -1,0 +1,66 @@
+package com.example.ainotes.data.ai
+
+import android.util.Log
+import com.example.ainotes.BuildConfig
+import com.example.ainotes.data.model.Note
+import com.google.ai.client.generativeai.GenerativeModel
+import com.google.ai.client.generativeai.type.TextPart
+import com.google.ai.client.generativeai.type.content
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Utility for generating concise note titles using Gemini. The implementation
+ * gracefully falls back to a heuristic title when the API key is missing or the
+ * network request fails so that legacy Firestore documents continue to render.
+ */
+object NoteTitleGenerator {
+    private const val TAG = "NoteTitleGenerator"
+    private const val MODEL_NAME = "gemini-1.5-flash"
+
+    suspend fun generateTitle(transcript: String): String = withContext(Dispatchers.IO) {
+        val normalized = transcript.replace(Regex("\\s+"), " ").trim()
+        if (normalized.isEmpty()) {
+            return@withContext Note.fallbackTitleFromContent(transcript)
+        }
+
+        val apiKey = BuildConfig.GEMINI_API_KEY
+        if (apiKey.isBlank()) {
+            return@withContext Note.fallbackTitleFromContent(normalized)
+        }
+
+        try {
+            val prompt = content {
+                text("You are naming voice notes.")
+                text("Write a short descriptive title (max 8 words) for the transcript below.")
+                text("Do not use quotation marks or punctuation at the end.")
+                text("Transcript:\n$normalized")
+            }
+
+            val model = GenerativeModel(modelName = MODEL_NAME, apiKey = apiKey)
+            val response = model.generateContent(prompt)
+            val rawTitle = response.candidates.orEmpty()
+                .flatMap { candidate -> candidate.content?.parts.orEmpty() }
+                .filterIsInstance<TextPart>()
+                .joinToString(separator = " ") { it.text }
+                .lineSequence()
+                .firstOrNull()
+                ?.trim()
+                .orEmpty()
+
+            val cleaned = clean(rawTitle)
+            if (cleaned.isNotEmpty()) cleaned else Note.fallbackTitleFromContent(normalized)
+        } catch (t: Throwable) {
+            Log.w(TAG, "Failed to generate title with Gemini; using fallback", t)
+            Note.fallbackTitleFromContent(normalized)
+        }
+    }
+
+    private fun clean(input: String): String {
+        if (input.isBlank()) return ""
+        val collapsed = input.replace(Regex("\\s+"), " ").trim()
+        val withoutQuotes = collapsed.trim('"', '\'', '“', '”', '„')
+        val withoutTrailingPunctuation = withoutQuotes.trimEnd('.', ',', ';', ':', '!', '?', '\u2026')
+        return withoutTrailingPunctuation.take(Note.MAX_TITLE_LENGTH).trim()
+    }
+}

--- a/app/src/main/java/com/example/ainotes/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/ainotes/ui/screens/MainScreen.kt
@@ -137,6 +137,14 @@ fun MainScreen(
                                     .padding(16.dp)
                             ) {
                                 Text(
+                                    text = note.resolvedTitle,
+                                    color = onCard,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                Spacer(Modifier.height(6.dp))
+                                Text(
                                     text = note.content,
                                     color = onCard,
                                     fontSize = 16.sp,

--- a/app/src/main/java/com/example/ainotes/ui/screens/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/ainotes/ui/screens/NoteDetailScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
@@ -145,6 +146,14 @@ fun NoteDetailScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
+            Text(
+                text = note.resolvedTitle,
+                style = MaterialTheme.typography.headlineSmall,
+                color = Color.White,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/example/ainotes/viewmodel/RecordingViewModel.kt
+++ b/app/src/main/java/com/example/ainotes/viewmodel/RecordingViewModel.kt
@@ -11,6 +11,7 @@ import android.speech.SpeechRecognizer
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.ainotes.data.ai.NoteTitleGenerator
 import com.example.ainotes.data.model.Note
 import com.example.ainotes.data.repository.NotesRepository
 import com.google.firebase.auth.FirebaseAuth
@@ -103,10 +104,13 @@ class RecordingViewModel : ViewModel() {
         val uid = auth.currentUser?.uid
         if (uid == null) { onResult(false); return }
         val normalized = normalize(text)
-        val note = if (currentTranscriptionId == null) Note(content = normalized)
-        else Note(id = currentTranscriptionId!!, content = normalized)
         viewModelScope.launch {
             try {
+                val generatedTitle = NoteTitleGenerator.generateTitle(normalized)
+                val note = if (currentTranscriptionId == null) Note(content = normalized)
+                else Note(id = currentTranscriptionId!!, content = normalized)
+                note.title = generatedTitle
+
                 if (currentTranscriptionId == null) notesRepository.addNote(note)
                 else notesRepository.updateNote(note)
                 currentTranscriptionId = note.id


### PR DESCRIPTION
## Summary
- add a title field and fallback helpers to the Firestore Note model and expose it in the UI
- integrate a Gemini-backed NoteTitleGenerator that RecordingViewModel uses to name transcripts while gracefully handling missing API keys
- migrate legacy documents without titles, persist fallback values, and surface titles across the list and detail screens

